### PR TITLE
Made changes to special-button.tsx so that "Get Started" can redirect to /feed when user is signed IN

### DIFF
--- a/components/special-button.tsx
+++ b/components/special-button.tsx
@@ -1,13 +1,24 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { auth } from "@clerk/nextjs";
+import { redirect, useRouter } from "next/navigation";
 
 export const ButtonFlickeringLight = () => {
   const router = useRouter();
+  const { userId } = auth()
 
   return (
     <>
-      <button onClick={() => router.push(process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL!)}>
+      <button onClick={() => {
+        if (!userId){
+          router.push(process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL!);
+        }else{
+          redirect('/feed')
+        }}
+
+
+        
+}>
         <div className="light" />
         Get Started
       </button>


### PR DESCRIPTION
Hello Korabi, I love your repo however when I go to the main homepage and click GetStarted, it first redirects me to the "Sign Up page" and it should
but when I opened the webpage again when I am signed IN the button does nothing and the console provides with the following 
![image](https://github.com/Korabi123/dev-hub/assets/97389239/585d2de0-cd7a-4c41-841b-60411c7cb864)
So I simply made it a function that whenever its clicked, it first checks if the userID is invalid (there is no user) and then proceeds to sign up. else, it redirects to '/feed'
**Please run this code and check for errors BEFORE deploying it**

I came here from discord, my username is AvinashBoi from code with Antonio server.
If you would like, I can collaborate with you on this project. The opinion is yours!
Cheers 🍻
Avinash / ChopCodes
